### PR TITLE
Fix ades xml path to parse correct structure 

### DIFF
--- a/digest2/d2ades.c
+++ b/digest2/d2ades.c
@@ -264,7 +264,7 @@ tracklet *parse_ades(const char *filepath) {
     }
 
     xmlXPathContextPtr xpathCtx = xmlXPathNewContext(doc);
-    xmlXPathObjectPtr optical_nodes = xmlXPathEvalExpression("//ades/optical", xpathCtx);
+    xmlXPathObjectPtr optical_nodes = xmlXPathEvalExpression("//ades/obsBlock/obsData/optical", xpathCtx);
 
     if (optical_nodes == NULL) {
         fprintf(stderr, "Error: Nothing found...");

--- a/digest2/d2ades.c
+++ b/digest2/d2ades.c
@@ -264,7 +264,7 @@ tracklet *parse_ades(const char *filepath) {
     }
 
     xmlXPathContextPtr xpathCtx = xmlXPathNewContext(doc);
-    xmlXPathObjectPtr optical_nodes = xmlXPathEvalExpression("//ades/obsBlock/obsData/optical", xpathCtx);
+    xmlXPathObjectPtr optical_nodes = xmlXPathEvalExpression("//optical", xpathCtx);
 
     if (optical_nodes == NULL) {
         fprintf(stderr, "Error: Nothing found...");

--- a/digest2/d2ades.c
+++ b/digest2/d2ades.c
@@ -198,9 +198,9 @@ _Bool processOptical(opticalPtr optical, observation *obsp) {
 
 
 
-        obsp->earth_observer[0] = strtod((char *) optical->pos1, NULL);
-        obsp->earth_observer[1] = strtod((char *) optical->pos2, NULL);
-        obsp->earth_observer[2] = strtod((char *) optical->pos3, NULL);
+        obsp->earth_observer[0] = x;
+        obsp->earth_observer[1] = y;
+        obsp->earth_observer[2] = z;
         obsp->spacebased = 1;
     }
 

--- a/digest2/digest2.obscodes
+++ b/digest2/digest2.obscodes
@@ -1230,6 +1230,7 @@ C54                           New Horizons
 C55                           Kepler
 C56                           LISA-Pathfinder
 C57                           TESS
+C58                           NEO Surveyor
 C59                           Yangwang-1
 C60   7.069260.634261+0.770545Argelander Institute for Astronomy Obs., Bonn
 C61   2.582020.658892+0.749723Chelles

--- a/digest2/sample.xml
+++ b/digest2/sample.xml
@@ -1,78 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ades version="2017">
-  <optical>
-    <provID>2016 SK99</provID>
-    <trkSub>C8QY322</trkSub>
-    <obsID>LZtCx18M0000F0eb010000LNh</obsID>
-    <trkID>00000H3GA8</trkID>
-    <mode>CCD</mode>
-    <stn>G96</stn>
-    <prog>01</prog>
-    <obsTime>2022-12-25T09:14:20.991Z</obsTime>
-    <ra>128.151180</ra>
-    <dec>17.176650</dec>
-    <rmsRA>0.247</rmsRA>
-    <rmsDec>0.301</rmsDec>
-    <rmsCorr>-0.0054</rmsCorr>
-    <astCat>Gaia2</astCat>
-    <mag>21.98</mag>
-    <rmsMag>0.318</rmsMag>
-    <band>G</band>
-    <photCat>Gaia2</photCat>
-    <logSNR>0.600</logSNR>
-    <rmsFit>0.088</rmsFit>
-    <nStars>7181</nStars>
-    <ref>MPS  1726996</ref>
-    <subFmt>A17</subFmt>
-  </optical>
-  <optical>
-    <provID>2016 SK99</provID>
-    <trkSub>C8QY322</trkSub>
-    <obsID>LZtCx18M0000F0eb010000LNi</obsID>
-    <trkID>00000H3GA8</trkID>
-    <mode>CCD</mode>
-    <stn>G96</stn>
-    <prog>01</prog>
-    <obsTime>2022-12-25T09:29:11.606Z</obsTime>
-    <ra>128.148480</ra>
-    <dec>17.177020</dec>
-    <rmsRA>0.431</rmsRA>
-    <rmsDec>0.438</rmsDec>
-    <rmsCorr>0.0</rmsCorr>
-    <astCat>Gaia2</astCat>
-    <mag>21.72</mag>
-    <rmsMag>0.328</rmsMag>
-    <band>G</band>
-    <photCat>Gaia2</photCat>
-    <logSNR>0.599</logSNR>
-    <rmsFit>0.083</rmsFit>
-    <nStars>7181</nStars>
-    <ref>MPS  1726996</ref>
-    <subFmt>A17</subFmt>
-  </optical>
-  <optical>
-    <provID>2016 SK99</provID>
-    <trkSub>C8QY322</trkSub>
-    <obsID>LZtCx18M0000F0eb010000LNj</obsID>
-    <trkID>00000H3GA8</trkID>
-    <mode>CCD</mode>
-    <stn>G96</stn>
-    <prog>01</prog>
-    <obsTime>2022-12-25T09:36:34.723Z</obsTime>
-    <ra>128.147805</ra>
-    <dec>17.177050</dec>
-    <rmsRA>0.561</rmsRA>
-    <rmsDec>0.573</rmsDec>
-    <rmsCorr>0.0</rmsCorr>
-    <astCat>Gaia2</astCat>
-    <mag>21.31</mag>
-    <rmsMag>0.327</rmsMag>
-    <band>G</band>
-    <photCat>Gaia2</photCat>
-    <logSNR>0.576</logSNR>
-    <rmsFit>0.085</rmsFit>
-    <nStars>7181</nStars>
-    <ref>MPS  1726996</ref>
-    <subFmt>A17</subFmt>
-  </optical>
+  <obsBlock>
+    <obsData>
+      <optical>
+        <provID>2016 SK99</provID>
+        <trkSub>C8QY322</trkSub>
+        <obsID>LZtCx18M0000F0eb010000LNh</obsID>
+        <trkID>00000H3GA8</trkID>
+        <mode>CCD</mode>
+        <stn>G96</stn>
+        <prog>01</prog>
+        <obsTime>2022-12-25T09:14:20.991Z</obsTime>
+        <ra>128.151180</ra>
+        <dec>17.176650</dec>
+        <rmsRA>0.247</rmsRA>
+        <rmsDec>0.301</rmsDec>
+        <rmsCorr>-0.0054</rmsCorr>
+        <astCat>Gaia2</astCat>
+        <mag>21.98</mag>
+        <rmsMag>0.318</rmsMag>
+        <band>G</band>
+        <photCat>Gaia2</photCat>
+        <logSNR>0.600</logSNR>
+        <rmsFit>0.088</rmsFit>
+        <nStars>7181</nStars>
+        <ref>MPS  1726996</ref>
+        <subFmt>A17</subFmt>
+      </optical>
+      <optical>
+        <provID>2016 SK99</provID>
+        <trkSub>C8QY322</trkSub>
+        <obsID>LZtCx18M0000F0eb010000LNi</obsID>
+        <trkID>00000H3GA8</trkID>
+        <mode>CCD</mode>
+        <stn>G96</stn>
+        <prog>01</prog>
+        <obsTime>2022-12-25T09:29:11.606Z</obsTime>
+        <ra>128.148480</ra>
+        <dec>17.177020</dec>
+        <rmsRA>0.431</rmsRA>
+        <rmsDec>0.438</rmsDec>
+        <rmsCorr>0.0</rmsCorr>
+        <astCat>Gaia2</astCat>
+        <mag>21.72</mag>
+        <rmsMag>0.328</rmsMag>
+        <band>G</band>
+        <photCat>Gaia2</photCat>
+        <logSNR>0.599</logSNR>
+        <rmsFit>0.083</rmsFit>
+        <nStars>7181</nStars>
+        <ref>MPS  1726996</ref>
+        <subFmt>A17</subFmt>
+      </optical>
+      <optical>
+        <provID>2016 SK99</provID>
+        <trkSub>C8QY322</trkSub>
+        <obsID>LZtCx18M0000F0eb010000LNj</obsID>
+        <trkID>00000H3GA8</trkID>
+        <mode>CCD</mode>
+        <stn>G96</stn>
+        <prog>01</prog>
+        <obsTime>2022-12-25T09:36:34.723Z</obsTime>
+        <ra>128.147805</ra>
+        <dec>17.177050</dec>
+        <rmsRA>0.561</rmsRA>
+        <rmsDec>0.573</rmsDec>
+        <rmsCorr>0.0</rmsCorr>
+        <astCat>Gaia2</astCat>
+        <mag>21.31</mag>
+        <rmsMag>0.327</rmsMag>
+        <band>G</band>
+        <photCat>Gaia2</photCat>
+        <logSNR>0.576</logSNR>
+        <rmsFit>0.085</rmsFit>
+        <nStars>7181</nStars>
+        <ref>MPS  1726996</ref>
+        <subFmt>A17</subFmt>
+      </optical>
+    </obsData>
+  </obsBlock>
 </ades>

--- a/digest2/sample.xml
+++ b/digest2/sample.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ades version="2017">
-  <obsBlock>
-    <obsData>
       <optical>
         <provID>2016 SK99</provID>
         <trkSub>C8QY322</trkSub>
@@ -77,6 +75,4 @@
         <ref>MPS  1726996</ref>
         <subFmt>A17</subFmt>
       </optical>
-    </obsData>
-  </obsBlock>
 </ades>

--- a/digest2/sample1.xml
+++ b/digest2/sample1.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ades version="2017">
+<obsBlock>
+<obsData>
 <optical>
 <provID>2023 MO1</provID>
 <trkSub>P11GiqT</trkSub>
@@ -84,4 +86,6 @@
 <ref>MPEC 2023-M77</ref>
 <subFmt>A17</subFmt>
 </optical>
+</obsData>
+</obsBlock>
 </ades>


### PR DESCRIPTION
ADES path parser was using a truncated ades/optical structure that was not valid as it needs the obsBlock and obsContext paths to match standard ADES formats.

In addition, added C58 to the obscode list